### PR TITLE
Exclude ComputeTable from building

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,7 @@
 {port_sources, ["c_src/*.cc", 
                 "c_src/snappy/*.cc"]}.
 {port_env, [
+    {"CXXFLAGS", "$CXXFLAGS -DNDEBUG"},
     {"(linux|solaris)", "LDFLAGS", "$LDFLAGS -lstdc++"}
 ]}.
 {so_name, "snappy_nif.so"}.


### PR DESCRIPTION
Set NDEBUG as CXXFLAGS to skip the compilation of this debug function.

The NDEBUG logic is broken because REGISTER_MODULE_INITIALIZER(snappy,
ComputeTable()); is set to always result to nothing, independently of
NDEBUG.

If debug tests should instead be included in the build, both NDEBUG
must not be set (as before) but also, REGISTER_MODULE_INITIALIZER
repaired.

COUCHDB-2463
