### PR TITLE
Support big-endian builds

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,12 @@
+case <<1:16/native>> of
+    <<1,0>> ->
+        CONFIG;
+    <<0,1>> ->
+        CXXFLAGS = [{"CXXFLAGS", "$CXXFLAGS -DWORDS_BIGENDIAN"}],
+        case lists:keyfind(port_env, 1, CONFIG) of
+            false ->
+                CONFIG ++ [{port_env, CXXFLAGS}];
+            {K, V} ->
+                lists:keyreplace(K, 1, CONFIG, {K, V ++ CXXFLAGS})
+        end
+end.


### PR DESCRIPTION
Google snappy's configure script defines WORDS_BIGENDIAN in config.h if it detects that the build machine is big-endian. rebar should do the same when building the C++ code for this NIF. This patch allows CouchDB to be built and run on big-endian Linux systems, e.g. ppc64, s390x, etc.