### PR TITLE
Support snappy Windows compilation

### DIFF
--- a/c_src/snappy/snappy-stubs-internal.h
+++ b/c_src/snappy/snappy-stubs-internal.h
@@ -45,6 +45,11 @@
 #include <sys/mman.h>
 #endif
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include "snappy-stubs-public.h"
 
 #if defined(__x86_64__)


### PR DESCRIPTION
Windows does not understand ssize_t, so this change brings in the relevant header file. A more autoconf-y way of doing it might be to put the change into a new config.h file and set the HAVE_CONFIG_H flag. That would maintain closer compatibility with the original snappy code, but be a bit more complex in rebar configuration.

Bringing in BaseTsd.h generates quite a lot of compiler cruft. We might just directly typedef ssize_t to something, but that runs the risk of errors in the future if the right thing to typedef it to changes.