### PR TITLE
Fix memory bug in SnappyNifSink::Append

### DIFF
--- a/c_src/snappy_nif.cc
+++ b/c_src/snappy_nif.cc
@@ -40,7 +40,7 @@ class SnappyNifSink : public snappy::Sink
         
         void Append(const char* data, size_t n);
         char* GetAppendBuffer(size_t len, char* scratch);
-        ErlNifBinary& getBin();
+        ErlNifBinary& GetBin();
 
     private:
         ErlNifEnv* env;
@@ -89,7 +89,7 @@ SnappyNifSink::GetAppendBuffer(size_t len, char* scratch)
 }
 
 ErlNifBinary&
-SnappyNifSink::getBin()
+SnappyNifSink::GetBin()
 {
     if(bin.size > length) {
         if(!enif_realloc_binary_compat(env, &bin, length)) {
@@ -143,7 +143,7 @@ snappy_compress(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         snappy::ByteArraySource source(SC_PTR(input.data), input.size);
         SnappyNifSink sink(env);
         snappy::Compress(&source, &sink);
-        return make_ok(env, enif_make_binary(env, &sink.getBin()));
+        return make_ok(env, enif_make_binary(env, &sink.GetBin()));
     } catch(std::bad_alloc e) {
         return make_error(env, "insufficient_memory");
     } catch(...) {


### PR DESCRIPTION
Previously `SnappyNifSink` assumed that `GetAppendBuffer` was always
called before `Append`. This turned out to be an invalid assumption.
This was definitely in the land of "How did that even work?". The simple
fix is simple.

This also pre-allocates the write buffer to 8192 bytes which just saves
us from the initial re-allocation on first `Append` since we allocated a
zero length buffer initially.