### PR TITLE
Remove required otp version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@ Makefile
 ebin
 priv
 .eunit
+*.d
 *.o
 *.lo
 *.la
 *~
 *.swp
+compile_commands.json

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,3 @@
-{require_otp_vsn, "R14|R15|R16|17|18|19|20|21|22|23|24|25"}.
-
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_sources, ["c_src/*.cc", 
                 "c_src/snappy/*.cc"]}.


### PR DESCRIPTION
Maintaining a required OTP version may be more trouble than it's worth, so rather than keep updating, let's try removing this line, and address any problems as they arise.

Also git ignore some compilation artifacts.